### PR TITLE
chg: [templates] CIRCL typo fix + rel=noreferrer on external links

### DIFF
--- a/app/templates/about_us.html
+++ b/app/templates/about_us.html
@@ -357,10 +357,10 @@
                                 <div class="d-flex gap-2 mt-3">
                                     <!-- redirect t https://github.com/ngsoti-->
 
-                                    <a href="https://github.com/ngsoti" target="_blank"
+                                    <a href="https://github.com/ngsoti" rel="noreferrer" target="_blank"
                                         class="badge bg-primary-subtle text-primary border border-primary-subtle">NGSOTI
                                         project</a>
-                                    <a href="https://circl.lu/" target="_blank" class="badge bg-dark text-white">CIRCL
+                                    <a href="https://www.circl.lu" rel="noreferrer" target="_blank" class="badge bg-dark text-white">CIRCL
                                         Project</a>
                                 </div>
                             </div>

--- a/app/templates/about_us.html
+++ b/app/templates/about_us.html
@@ -342,7 +342,7 @@
                             <div class="card-body p-4">
                                 <h6 class="fw-bold text-dark mb-3">
                                     <i class="fa-solid fa-building-columns me-2 text-primary"></i>
-                                    The CRCL Initiative
+                                    The CIRCL Initiative
                                 </h6>
                                 <p class="small text-secondary">
                                     Rulezet is an initiative led by the <strong>The Computer Incident Response Center
@@ -360,7 +360,7 @@
                                     <a href="https://github.com/ngsoti" target="_blank"
                                         class="badge bg-primary-subtle text-primary border border-primary-subtle">NGSOTI
                                         project</a>
-                                    <a href="https://circl.lu/" target="_blank" class="badge bg-dark text-white">CRCL
+                                    <a href="https://circl.lu/" target="_blank" class="badge bg-dark text-white">CIRCL
                                         Project</a>
                                 </div>
                             </div>

--- a/app/templates/account/request_detail.html
+++ b/app/templates/account/request_detail.html
@@ -38,7 +38,7 @@
                         <li class="list-group-item">
                             <strong><i class="fas fa-link me-2 text-secondary"></i>Rule Source:</strong>
                             <span class="ms-2" v-if="current_request.rule_source">
-                            <a :href="current_request.rule_source" target="_blank" class="text-decoration-none">
+                            <a :href="current_request.rule_source" rel="noreferrer" target="_blank" class="text-decoration-none">
                                 [[ current_request.rule_source ]]
                             </a>
                             </span>

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -28,7 +28,7 @@
                         </a>
                     </li>
                     <li class="list-inline-item px-2">
-                        <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank"
+                        <a href="https://www.gnu.org/licenses/agpl-3.0.html" rel="noreferrer" target="_blank"
                             class="text-decoration-none text-light opacity-75 hover-opacity-100 small fw-semibold">
                             <i class="fa-solid fa-balance-scale me-1"></i> Licenses
                         </a>

--- a/app/templates/rule/bad_rules_summary.html
+++ b/app/templates/rule/bad_rules_summary.html
@@ -73,7 +73,7 @@
 
                         <div class="mb-3">
                             <div class="text-muted" style="font-size: 0.75rem;">SOURCE ORIGIN</div>
-                            <a :href="rule.url" target="_blank"
+                            <a :href="rule.url" rel="noreferrer" target="_blank"
                                 class="small text-primary text-decoration-none d-block text-truncate">
                                 <i class="fas fa-external-link-alt me-1" style="font-size: 0.7rem;"></i>[[ rule.url ]]
                             </a>

--- a/app/templates/rule/detail_rule.html
+++ b/app/templates/rule/detail_rule.html
@@ -169,7 +169,7 @@
                                             <small class="text-truncate">
                                                 <template
                                                     v-if="currentRule.source && currentRule.source.startsWith('http')">
-                                                    <a :href="currentRule.source" target="_blank"
+                                                    <a :href="currentRule.source" rel="noreferrer" target="_blank"
                                                         class="text-primary text-decoration-none">
                                                         [[ currentRule.source ]]
                                                     </a>

--- a/app/templates/rule/update_github/update_loading.html
+++ b/app/templates/rule/update_github/update_loading.html
@@ -70,7 +70,7 @@
                                     </tr>
                                     <tr>
                                         <td>Repo URL</td>
-                                        <td><a :href="repo.url" target="_blank">[[ repo.url ]]</a></td>
+                                        <td><a :href="repo.url" rel="noreferrer" target="_blank">[[ repo.url ]]</a></td>
                                     </tr>
                                 </table>
                             </div>

--- a/app/templates/rule/update_github/updates_choose_changes.html
+++ b/app/templates/rule/update_github/updates_choose_changes.html
@@ -46,7 +46,7 @@
                     </li>
                     <li class="list-group-item" title="Update found from GitHub"><strong>Rule
                             Source:</strong>
-                        <a :href="owner_rule.rule_source" target="_blank" class="stretched-link"></a>
+                        <a :href="owner_rule.rule_source" rel="noreferrer" target="_blank" class="stretched-link"></a>
                         [[ owner_rule.rule_source ]]
                     </li>
                 </ul>

--- a/app/templates/rule/url_github/detail_url_github.html
+++ b/app/templates/rule/url_github/detail_url_github.html
@@ -13,7 +13,7 @@
     <div class="card shadow-sm mx-auto hover-shadow cursor-pointer" style="transition: transform 0.2s;">
       <div class="card-body text-truncate">
         <i class="fa-brands fa-github me-2 text-dark"></i> Source URL:
-        <strong><a href="{{ url }}" target="_blank" class="stretched-link"></a> {{ url }}</strong>
+        <strong><a href="{{ url }}" rel="noreferrer" target="_blank" class="stretched-link"></a> {{ url }}</strong>
       </div>
     </div>
   </div>

--- a/app/templates/rule/url_github/import_loading.html
+++ b/app/templates/rule/url_github/import_loading.html
@@ -27,7 +27,7 @@
                 Import completed successfully.
                 You can now view the imported rules and their details below.
                 <span class="text-primary">
-                    <a :href="info_session.repo_url" target="_blank">
+                    <a :href="info_session.repo_url" rel="noreferrer" target="_blank">
                         [[info_session.repo_url]]
                     </a>
                 </span>.


### PR DESCRIPTION
## Summary

Two small, unrelated template fixes:

- **`fix: [about_us] typo CRCL -> CIRCL`** (`851f553`) — corrects the CIRCL acronym in `app/templates/about_us.html` (heading "The CIRCL Initiative" and the badge link label). Content-only, no behavior change.
- **`chg: [templates] add rel=noreferrer on external links`** (`2e5301a`) — adds `rel="noreferrer"` to external `<a>` tags that open in a new tab, so the `Referer` header (which on authenticated pages can include rule IDs and other path data) is not leaked to third-party destinations. Links to `github.com/rulezet/rulezet-core` are intentionally left untouched so referrer-based traffic attribution to the project's own repo still works.

Templates touched by the second commit:
- `app/templates/account/request_detail.html` — `current_request.rule_source`
- `app/templates/footer.html` — AGPL license link
- `app/templates/rule/bad_rules_summary.html` — `rule.url`
- `app/templates/rule/detail_rule.html` — `currentRule.source`
- `app/templates/rule/update_github/update_loading.html` — `repo.url`
- `app/templates/rule/update_github/updates_choose_changes.html` — `owner_rule.rule_source`
- `app/templates/rule/url_github/detail_url_github.html` — `{{ url }}`
- `app/templates/rule/url_github/import_loading.html` — `info_session.repo_url`
- `app/templates/about_us.html` — NGSOTI + CIRCL badge links

## Test plan

- [ ] Load the About page and confirm the heading reads "The CIRCL Initiative" and the badge reads "CIRCL Project".
- [ ] Open a rule detail page, click the external source link, and confirm it opens in a new tab with no `Referer` header sent (check the destination or browser devtools).
- [ ] Click an external link on a bad-rule summary, request detail, GitHub import/update flow, and the AGPL license link in the footer — same check.
- [ ] Click any `github.com/rulezet/rulezet-core` link (footer / about page / why page) and confirm the `Referer` header **is still sent** (referrer attribution preserved).