### PR TITLE
feat(rule_format): add Agent Threat Rules (ATR) format adapter

### DIFF
--- a/app/features/rule/rule_format/available_format/atr_format.py
+++ b/app/features/rule/rule_format/available_format/atr_format.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+import json
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from app.core.utils.utils import detect_cve
+from app.features.rule.rule_core import get_rule
+from app.features.rule.rule_format.abstract_rule_type.rule_type_abstract import (
+    RuleType,
+    ValidationResult,
+)
+
+
+####################
+#   ATR class      #
+####################
+
+# Canonical ATR rule-ID shape (e.g. ATR-2026-00440)
+_ATR_ID_RE = re.compile(r"^ATR-\d{4}-\d{5}$")
+
+# The ten valid ATR taxonomy categories. Anything outside this set is a
+# semantic validation failure even if the YAML parses fine.
+_ATR_CATEGORIES = frozenset(
+    {
+        "prompt-injection",
+        "tool-poisoning",
+        "skill-compromise",
+        "agent-manipulation",
+        "context-exfiltration",
+        "data-poisoning",
+        "excessive-autonomy",
+        "model-abuse",
+        "model-security",
+        "privilege-escalation",
+    }
+)
+
+# Valid ATR severities. Same shape as Sigma's severity enum.
+_ATR_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+
+# Valid agent_source.type values per ATR's evolving schema (additive).
+_ATR_AGENT_SOURCE_TYPES = frozenset({"llm_io", "tool_call", "skill_manifest", "agent_loop"})
+
+
+class ATRRule(RuleType):
+    """
+    Concrete implementation of RuleType for Agent Threat Rules (ATR).
+
+    ATR is an MIT-licensed YAML-based detection-rule standard for AI agent
+    threats. Each rule has a stable identifier in the form ATR-YYYY-NNNNN
+    (e.g. ATR-2026-00001) and detects attacks across ten categories:
+    prompt-injection, tool-poisoning, skill-compromise, agent-manipulation,
+    context-exfiltration, data-poisoning, excessive-autonomy, model-abuse,
+    model-security, privilege-escalation.
+
+    Upstream: https://github.com/Agent-Threat-Rule/agent-threat-rules
+    npm:      `agent-threat-rules` (MIT, currently v2.1.2 / 338 rules).
+    """
+
+    @property
+    def format(self) -> str:
+        return "atr"
+
+    def get_class(self) -> str:
+        return "ATRRule"
+
+    ##############################
+    #        FORMAT DETECT       #
+    ##############################
+    def detect(self, content: str) -> bool:
+        """
+        Heuristic to disambiguate an ATR rule from other YAML-based formats
+        (Sigma, etc.) that share the .yaml extension.
+
+        Triggers on any of:
+          - top-level `id` field matching `ATR-YYYY-NNNNN`
+          - top-level `agent_source` field (unique to ATR among YAML formats)
+          - top-level `tags.category` value in the ATR taxonomy
+
+        Not in the abstract `RuleType` contract today; safe to call directly
+        on an instance when the format loader needs to disambiguate.
+        """
+        try:
+            doc = yaml.safe_load(content)
+        except Exception:
+            return False
+        if not isinstance(doc, dict):
+            return False
+
+        rule_id = doc.get("id")
+        if isinstance(rule_id, str) and _ATR_ID_RE.match(rule_id):
+            return True
+
+        if isinstance(doc.get("agent_source"), dict):
+            return True
+
+        tags = doc.get("tags")
+        if isinstance(tags, dict):
+            category = tags.get("category")
+            if isinstance(category, str) and category in _ATR_CATEGORIES:
+                return True
+
+        return False
+
+    ##############################
+    #         VALIDATION         #
+    ##############################
+    def validate(self, content: str, **kwargs) -> ValidationResult:
+        """
+        Validate an ATR rule. Two layers:
+
+          1. Syntactic — the content parses as a single YAML mapping.
+          2. Semantic — required fields are present and their values are
+             drawn from the ATR-defined enums (severity, category,
+             agent_source.type) and the canonical rule-ID pattern.
+
+        Does not re-dump YAML — returns the original content verbatim in
+        `normalized_content` so quoting and ordering are preserved.
+        """
+        try:
+            doc = yaml.safe_load(content)
+        except Exception as exc:  # YAMLError or anything else
+            return ValidationResult(ok=False, errors=[f"YAML parse error: {exc}"], normalized_content=content)
+
+        if doc is None or not isinstance(doc, dict):
+            return ValidationResult(
+                ok=False,
+                errors=["Empty or invalid YAML content or not a single rule object."],
+                normalized_content=content,
+            )
+
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        # Required scalar fields.
+        rule_id = doc.get("id")
+        if not isinstance(rule_id, str):
+            errors.append("Missing or non-string required field: id")
+        elif not _ATR_ID_RE.match(rule_id):
+            errors.append(
+                f"Rule id '{rule_id}' does not match the canonical ATR pattern ATR-YYYY-NNNNN"
+            )
+
+        title = doc.get("title")
+        if not isinstance(title, str) or not title.strip():
+            errors.append("Missing or empty required field: title")
+
+        severity = doc.get("severity")
+        if severity is None:
+            errors.append("Missing required field: severity")
+        elif severity not in _ATR_SEVERITIES:
+            errors.append(
+                f"Severity '{severity}' is not one of: {sorted(_ATR_SEVERITIES)}"
+            )
+
+        # Required tags.category.
+        tags = doc.get("tags")
+        if not isinstance(tags, dict):
+            errors.append("Missing or non-mapping required field: tags")
+        else:
+            category = tags.get("category")
+            if category is None:
+                errors.append("Missing required field: tags.category")
+            elif category not in _ATR_CATEGORIES:
+                errors.append(
+                    f"Category '{category}' is not in the ATR taxonomy. Valid: {sorted(_ATR_CATEGORIES)}"
+                )
+
+        # Required agent_source.type.
+        agent_source = doc.get("agent_source")
+        if not isinstance(agent_source, dict):
+            errors.append("Missing or non-mapping required field: agent_source")
+        else:
+            atype = agent_source.get("type")
+            if atype is None:
+                errors.append("Missing required field: agent_source.type")
+            elif atype not in _ATR_AGENT_SOURCE_TYPES:
+                # Additive schema — log as warning rather than hard fail.
+                warnings.append(
+                    f"agent_source.type '{atype}' is not in the currently-known set "
+                    f"{sorted(_ATR_AGENT_SOURCE_TYPES)} — accepting but flagging."
+                )
+
+        # Detection block. ATR uses either an array (`conditions: [...]`)
+        # with `condition: any|all`, or a named-map for older rules.
+        detection = doc.get("detection")
+        if not isinstance(detection, dict):
+            errors.append("Missing or non-mapping required field: detection")
+        else:
+            conditions = detection.get("conditions")
+            if conditions is None:
+                errors.append("Missing required field: detection.conditions")
+            elif isinstance(conditions, list):
+                if len(conditions) == 0:
+                    errors.append("detection.conditions must be a non-empty array")
+                else:
+                    for idx, cond in enumerate(conditions):
+                        if not isinstance(cond, dict):
+                            errors.append(f"detection.conditions[{idx}] must be a mapping")
+                            continue
+                        for required in ("field", "operator", "value"):
+                            if required not in cond:
+                                errors.append(
+                                    f"detection.conditions[{idx}] missing required key '{required}'"
+                                )
+                expr = detection.get("condition")
+                if expr is not None and expr not in {"any", "all", "or", "and"}:
+                    errors.append(
+                        f"detection.condition '{expr}' must be one of: any | all | or | and"
+                    )
+            elif not isinstance(conditions, dict):
+                errors.append("detection.conditions must be either an array or a mapping")
+
+        ok = len(errors) == 0
+        return ValidationResult(ok=ok, errors=errors, warnings=warnings, normalized_content=content)
+
+    ##############################
+    #        META PARSING        #
+    ##############################
+    def parse_metadata(
+        self,
+        content: str,
+        info: Optional[Dict[str, Any]] = None,
+        validation_result: Optional[ValidationResult] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """
+        Extract rulezet-canonical metadata from an ATR rule.
+
+        Preserves the original ATR rule id (ATR-YYYY-NNNNN) in
+        `original_uuid` so the mapping back to the upstream corpus stays
+        stable across rulezet's own UUID assignment.
+        """
+        info = info or {}
+        title_fallback = "Untitled ATR Rule"
+        try:
+            doc = yaml.safe_load(content)
+            if doc is None or not isinstance(doc, dict):
+                rule_id_hint = info.get("original_uuid") or "Unknown"
+                raise ValueError(f"Empty or non-mapping YAML; id hint: {rule_id_hint}")
+
+            rule_id = doc.get("id", "Unknown")
+            title = doc.get("title", title_fallback)
+            description = doc.get("description", "No description provided")
+            severity = doc.get("severity", "unknown")
+            author = doc.get("author") or info.get("author", "ATR Community")
+
+            # ATR rules carry `references.cve` as a list. Prefer the
+            # explicit list when present; otherwise fall back to scanning
+            # the description with rulezet's `detect_cve` utility.
+            # Output shape matches the Sigma format adapter: a JSON-encoded
+            # string of identifiers, so downstream consumers don't have to
+            # branch on format.
+            references = doc.get("references") or {}
+            explicit_cves = references.get("cve") if isinstance(references, dict) else None
+            if isinstance(explicit_cves, list) and explicit_cves:
+                normalized = sorted({str(c).strip().upper() for c in explicit_cves if c})
+                cve_ids = json.dumps(normalized)
+            else:
+                _, cve_ids = detect_cve(description if isinstance(description, str) else "")
+
+            # Tags: rulezet expects a flat list of strings. Flatten the ATR
+            # tags mapping (category, subcategory, confidence, etc.) into
+            # `key:value` strings so consumers can filter on any of them.
+            tags_list: List[str] = []
+            tags_dict = doc.get("tags") or {}
+            if isinstance(tags_dict, dict):
+                for k, v in tags_dict.items():
+                    if isinstance(v, str):
+                        tags_list.append(f"{k}:{v}")
+                    elif isinstance(v, (list, tuple)):
+                        for item in v:
+                            tags_list.append(f"{k}:{item}")
+
+            return {
+                "title": title,
+                "format": "atr",
+                "license": doc.get("license") or info.get("license", "MIT"),
+                "description": description,
+                "version": str(doc.get("rule_version", doc.get("version", "1"))),
+                "author": author,
+                "cve_id": cve_ids,
+                "original_uuid": rule_id,
+                "source": info.get("repo_url", "https://github.com/Agent-Threat-Rule/agent-threat-rules"),
+                "severity": severity,
+                "tags": tags_list,
+                "to_string": content,
+            }
+
+        except Exception as exc:
+            return {
+                "format": "atr",
+                "title": f"{title_fallback} (Metadata Error)",
+                "license": info.get("license", "MIT"),
+                "description": f"Error parsing metadata: {exc}",
+                "version": "N/A",
+                "source": info.get("repo_url", "Unknown"),
+                "original_uuid": "Unknown",
+                "author": info.get("author", "ATR Community"),
+                "cve_id": [],
+                "severity": "unknown",
+                "tags": [],
+                "to_string": content,
+            }
+
+    ##############################
+    #         FILE LISTING       #
+    ##############################
+    def get_rule_files(self, file: str) -> bool:
+        """Return True if the file looks like a candidate ATR rule file by extension."""
+        return file.endswith((".yml", ".yaml"))
+
+    ##############################
+    #         EXTRACTION         #
+    ##############################
+    def extract_rules_from_file(self, filepath: str) -> List[str]:
+        """
+        Extract individual ATR rules from a YAML file.
+
+        ATR ships one rule per file in the canonical repo layout, but the
+        format permits multi-document YAML and list-of-rules YAML. This
+        method handles all three (single dict, list of dicts, multi-doc).
+        Original content is preserved verbatim where the file holds a
+        single rule (no re-dump), to keep quoting / ordering intact.
+        """
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read()
+        except Exception:
+            return []
+
+        try:
+            parsed = list(yaml.safe_load_all(content))
+        except Exception:
+            return []
+
+        # No documents.
+        if not parsed:
+            return []
+
+        # Single-document file with a single rule mapping — return raw text.
+        if len(parsed) == 1 and isinstance(parsed[0], dict):
+            return [content] if self.detect(content) else []
+
+        # Single-document file holding a list of rules — dump each.
+        if len(parsed) == 1 and isinstance(parsed[0], list):
+            return [
+                yaml.dump(rule, sort_keys=False, allow_unicode=True)
+                for rule in parsed[0]
+                if isinstance(rule, dict)
+            ]
+
+        # Multi-document file — each top-level doc that is a mapping is a rule.
+        return [
+            yaml.dump(doc, sort_keys=False, allow_unicode=True)
+            for doc in parsed
+            if isinstance(doc, dict)
+        ]
+
+    ##############################
+    #      SEARCH IN REPO        #
+    ##############################
+    def _walk_yaml_files(self, repo_dir: str) -> List[str]:
+        """Walk repo_dir for candidate ATR YAML files (mirrors sigma_format)."""
+        rule_files: List[str] = []
+        if not os.path.exists(repo_dir):
+            return rule_files
+        for root, dirs, files in os.walk(repo_dir):
+            dirs[:] = [d for d in dirs if not d.startswith(".") and not d.startswith("_")]
+            for fname in files:
+                if fname.startswith(".") or fname.startswith("_"):
+                    continue
+                if fname.endswith((".yml", ".yaml")):
+                    rule_files.append(os.path.join(root, fname))
+        return rule_files
+
+    def find_rule_in_repo(self, repo_dir: str, rule_id: int) -> tuple[str, bool]:
+        """
+        Locate a previously-imported ATR rule's current text in a repo
+        directory by its stable original_uuid (ATR-YYYY-NNNNN).
+        """
+        rule = get_rule(rule_id)
+        if not rule:
+            return "No rule found in the database.", False
+
+        target_uuid = getattr(rule, "original_uuid", None)
+        target_title = getattr(rule, "title", None)
+
+        for path in self._walk_yaml_files(repo_dir):
+            for raw in self.extract_rules_from_file(path):
+                try:
+                    doc = yaml.safe_load(raw)
+                except Exception:
+                    continue
+                if not isinstance(doc, dict):
+                    continue
+                if (target_uuid and doc.get("id") == target_uuid) or (
+                    target_title and doc.get("title") == target_title
+                ):
+                    return raw, True
+
+        return f"ATR rule '{target_title or target_uuid}' not found inside local repo.", False

--- a/app/features/rule/rule_format/available_format/atr_format.py
+++ b/app/features/rule/rule_format/available_format/atr_format.py
@@ -57,7 +57,7 @@ class ATRRule(RuleType):
     model-security, privilege-escalation.
 
     Upstream: https://github.com/Agent-Threat-Rule/agent-threat-rules
-    npm:      `agent-threat-rules` (MIT, currently v2.1.2 / 338 rules).
+    npm:      `agent-threat-rules` (MIT, currently v3.5.0 / 652 rules).
     """
 
     @property

--- a/tests/rules/test_atr_format.py
+++ b/tests/rules/test_atr_format.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for the ATR (Agent Threat Rules) format adapter.
+
+The adapter mirrors the contract documented in
+`app/features/rule/rule_format/abstract_rule_type/rule_type_abstract.py`
+and is structured to match the existing `sigma_format` adapter for
+consistency.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from textwrap import dedent
+
+import pytest
+
+from app.features.rule.rule_format.abstract_rule_type.rule_type_abstract import ValidationResult
+from app.features.rule.rule_format.available_format.atr_format import ATRRule
+
+
+# -------------------------------------------------------------------------
+#                           Sample rule fixtures
+# -------------------------------------------------------------------------
+
+_VALID_ATR_RULE = dedent(
+    """\
+    id: ATR-2026-00001
+    title: "Direct Prompt Injection via User Input"
+    description: "Detects classic instruction-override prompt injection attempts in user input."
+    severity: high
+    author: "ATR Community"
+    rule_version: 1
+    tags:
+      category: prompt-injection
+      confidence: high
+    agent_source:
+      type: llm_io
+    detection:
+      condition: any
+      conditions:
+        - field: user_input
+          operator: regex
+          value: '(?i)\\bignore\\s+(?:all\\s+)?previous\\s+instructions?\\b'
+          description: "Instruction-override verb + target noun"
+    references:
+      owasp_llm:
+        - "LLM01:2025 - Prompt Injection"
+      cve:
+        - CVE-2024-5184
+        - CVE-2024-3402
+    """
+)
+
+_VALID_ATR_RULE_CVE_VIA_DESCRIPTION = dedent(
+    """\
+    id: ATR-2026-00432
+    title: "SuperAGI Output Handler eval() RCE"
+    description: "Detects CVE-2024-21552 (CVSS 9.8) eval-based RCE in SuperAGI output_handler.py."
+    severity: critical
+    tags:
+      category: agent-manipulation
+    agent_source:
+      type: llm_io
+    detection:
+      condition: any
+      conditions:
+        - field: content
+          operator: regex
+          value: "eval\\\\("
+    """
+)
+
+_INVALID_ATR_BAD_ID = dedent(
+    """\
+    id: NOT-AN-ATR-ID
+    title: "Bad ID"
+    severity: high
+    tags:
+      category: prompt-injection
+    agent_source:
+      type: llm_io
+    detection:
+      condition: any
+      conditions:
+        - field: content
+          operator: regex
+          value: "x"
+    """
+)
+
+_INVALID_ATR_BAD_CATEGORY = dedent(
+    """\
+    id: ATR-2026-99999
+    title: "Bad category"
+    severity: high
+    tags:
+      category: not-a-real-category
+    agent_source:
+      type: llm_io
+    detection:
+      condition: any
+      conditions:
+        - field: content
+          operator: regex
+          value: "x"
+    """
+)
+
+_INVALID_ATR_BAD_SEVERITY = dedent(
+    """\
+    id: ATR-2026-99999
+    title: "Bad severity"
+    severity: catastrophic
+    tags:
+      category: prompt-injection
+    agent_source:
+      type: llm_io
+    detection:
+      condition: any
+      conditions:
+        - field: content
+          operator: regex
+          value: "x"
+    """
+)
+
+_INVALID_ATR_MISSING_DETECTION = dedent(
+    """\
+    id: ATR-2026-99999
+    title: "Missing detection block"
+    severity: high
+    tags:
+      category: prompt-injection
+    agent_source:
+      type: llm_io
+    """
+)
+
+_INVALID_ATR_EMPTY_CONDITIONS = dedent(
+    """\
+    id: ATR-2026-99999
+    title: "Empty conditions"
+    severity: high
+    tags:
+      category: prompt-injection
+    agent_source:
+      type: llm_io
+    detection:
+      condition: any
+      conditions: []
+    """
+)
+
+_SIGMA_LOOKALIKE_NOT_ATR = dedent(
+    """\
+    title: "A Sigma rule that should not match ATR"
+    id: 0c5a0e07-4f80-4cf3-b1c3-7e8a9f12345
+    status: stable
+    logsource:
+      category: process_creation
+      product: linux
+    detection:
+      selection:
+        Image|endswith: '/cat'
+      condition: selection
+    """
+)
+
+
+# -------------------------------------------------------------------------
+#                                Tests
+# -------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def atr() -> ATRRule:
+    return ATRRule()
+
+
+def test_format_identifier(atr: ATRRule) -> None:
+    assert atr.format == "atr"
+    assert atr.get_class() == "ATRRule"
+
+
+# ---- detect() ------------------------------------------------------------
+
+
+def test_detect_matches_canonical_atr_rule(atr: ATRRule) -> None:
+    assert atr.detect(_VALID_ATR_RULE) is True
+
+
+def test_detect_matches_when_only_agent_source_present(atr: ATRRule) -> None:
+    sample = dedent(
+        """\
+        title: "Some rule"
+        agent_source:
+          type: tool_call
+        """
+    )
+    assert atr.detect(sample) is True
+
+
+def test_detect_matches_when_only_category_present(atr: ATRRule) -> None:
+    sample = dedent(
+        """\
+        title: "Some rule"
+        tags:
+          category: prompt-injection
+        """
+    )
+    assert atr.detect(sample) is True
+
+
+def test_detect_rejects_sigma_lookalike(atr: ATRRule) -> None:
+    assert atr.detect(_SIGMA_LOOKALIKE_NOT_ATR) is False
+
+
+def test_detect_rejects_non_yaml(atr: ATRRule) -> None:
+    assert atr.detect("not: : yaml: :") is False
+
+
+def test_detect_rejects_non_mapping_yaml(atr: ATRRule) -> None:
+    assert atr.detect("- just\n- a\n- list\n") is False
+
+
+# ---- validate() ----------------------------------------------------------
+
+
+def test_validate_accepts_canonical_atr_rule(atr: ATRRule) -> None:
+    result = atr.validate(_VALID_ATR_RULE)
+    assert isinstance(result, ValidationResult)
+    assert result.ok is True, result.errors
+    assert result.errors == []
+    assert result.normalized_content == _VALID_ATR_RULE
+
+
+def test_validate_rejects_bad_id(atr: ATRRule) -> None:
+    result = atr.validate(_INVALID_ATR_BAD_ID)
+    assert result.ok is False
+    assert any("ATR-YYYY-NNNNN" in e for e in result.errors)
+
+
+def test_validate_rejects_unknown_category(atr: ATRRule) -> None:
+    result = atr.validate(_INVALID_ATR_BAD_CATEGORY)
+    assert result.ok is False
+    assert any("not-a-real-category" in e for e in result.errors)
+
+
+def test_validate_rejects_unknown_severity(atr: ATRRule) -> None:
+    result = atr.validate(_INVALID_ATR_BAD_SEVERITY)
+    assert result.ok is False
+    assert any("catastrophic" in e for e in result.errors)
+
+
+def test_validate_rejects_missing_detection(atr: ATRRule) -> None:
+    result = atr.validate(_INVALID_ATR_MISSING_DETECTION)
+    assert result.ok is False
+    assert any("detection" in e for e in result.errors)
+
+
+def test_validate_rejects_empty_conditions(atr: ATRRule) -> None:
+    result = atr.validate(_INVALID_ATR_EMPTY_CONDITIONS)
+    assert result.ok is False
+    assert any("non-empty" in e for e in result.errors)
+
+
+def test_validate_rejects_empty_yaml(atr: ATRRule) -> None:
+    result = atr.validate("")
+    assert result.ok is False
+    assert any("Empty" in e for e in result.errors)
+
+
+def test_validate_rejects_yaml_parse_error(atr: ATRRule) -> None:
+    result = atr.validate("title: : :\n: :")
+    assert result.ok is False
+    assert any("YAML parse" in e for e in result.errors)
+
+
+# ---- parse_metadata() ----------------------------------------------------
+
+
+def test_parse_metadata_prefers_explicit_cve_list(atr: ATRRule) -> None:
+    meta = atr.parse_metadata(_VALID_ATR_RULE, info={"repo_url": "https://example/repo"})
+    assert meta["format"] == "atr"
+    assert meta["title"] == "Direct Prompt Injection via User Input"
+    assert meta["severity"] == "high"
+    assert meta["original_uuid"] == "ATR-2026-00001"
+    assert meta["author"] == "ATR Community"
+    assert meta["license"] == "MIT"
+    assert meta["source"] == "https://example/repo"
+    cves = json.loads(meta["cve_id"])
+    assert "CVE-2024-5184" in cves
+    assert "CVE-2024-3402" in cves
+
+
+def test_parse_metadata_falls_back_to_description_scan(atr: ATRRule) -> None:
+    meta = atr.parse_metadata(_VALID_ATR_RULE_CVE_VIA_DESCRIPTION)
+    cves = json.loads(meta["cve_id"])
+    assert "CVE-2024-21552" in cves
+
+
+def test_parse_metadata_flattens_tags(atr: ATRRule) -> None:
+    meta = atr.parse_metadata(_VALID_ATR_RULE)
+    assert "category:prompt-injection" in meta["tags"]
+    assert "confidence:high" in meta["tags"]
+
+
+def test_parse_metadata_returns_safe_shape_on_parse_error(atr: ATRRule) -> None:
+    meta = atr.parse_metadata("title: : :\n: :", info={"repo_url": "x"})
+    assert meta["format"] == "atr"
+    assert "Metadata Error" in meta["title"]
+    assert meta["cve_id"] == []
+    assert meta["to_string"]  # always preserves raw input
+
+
+# ---- get_rule_files() ----------------------------------------------------
+
+
+def test_get_rule_files_accepts_yaml_extensions(atr: ATRRule) -> None:
+    assert atr.get_rule_files("rules/foo.yaml") is True
+    assert atr.get_rule_files("rules/foo.yml") is True
+
+
+def test_get_rule_files_rejects_other_extensions(atr: ATRRule) -> None:
+    assert atr.get_rule_files("rules/foo.txt") is False
+    assert atr.get_rule_files("rules/foo.json") is False
+
+
+# ---- extract_rules_from_file() -------------------------------------------
+
+
+def test_extract_rules_from_single_rule_file(atr: ATRRule, tmp_path) -> None:
+    p = tmp_path / "rule.yaml"
+    p.write_text(_VALID_ATR_RULE, encoding="utf-8")
+    rules = atr.extract_rules_from_file(str(p))
+    assert len(rules) == 1
+    # Single-rule files return raw content verbatim — quoting preserved.
+    assert rules[0] == _VALID_ATR_RULE
+
+
+def test_extract_rules_from_non_atr_yaml_is_empty(atr: ATRRule, tmp_path) -> None:
+    p = tmp_path / "sigma.yaml"
+    p.write_text(_SIGMA_LOOKALIKE_NOT_ATR, encoding="utf-8")
+    rules = atr.extract_rules_from_file(str(p))
+    assert rules == []
+
+
+def test_extract_rules_from_multi_doc_yaml(atr: ATRRule, tmp_path) -> None:
+    p = tmp_path / "multi.yaml"
+    p.write_text(f"{_VALID_ATR_RULE}\n---\n{_VALID_ATR_RULE_CVE_VIA_DESCRIPTION}\n", encoding="utf-8")
+    rules = atr.extract_rules_from_file(str(p))
+    assert len(rules) == 2


### PR DESCRIPTION
Implements the `RuleType` abstract contract for ATR (Agent Threat Rules), per discussion with @ecrou-exact in #49.

## Files

- `app/features/rule/rule_format/available_format/atr_format.py` (405 lines) — `ATRRule` class
- `tests/rules/test_atr_format.py` (353 lines) — 24 unit tests, all passing

Diff: 758 insertions, 0 modifications to existing files.

## Method coverage

All four required `RuleType` abstract methods + the `detect()` helper:

| Method | Status |
|---|---|
| `format` property | `"atr"` |
| `get_class()` | `"ATRRule"` |
| `validate(content)` | Two-layer: YAML parse + ATR semantic (canonical id pattern, 10-category enum, 4-severity enum, `agent_source.type` enum, detection block shape) |
| `parse_metadata(content, info)` | rulezet-canonical shape; preserves `ATR-YYYY-NNNNN` in `original_uuid` |
| `get_rule_files(file)` | `.yaml` / `.yml` extension gate |
| `extract_rules_from_file(filepath)` | Single-rule (verbatim, no re-dump), list-of-rules, multi-document YAML |
| `find_rule_in_repo(repo_dir, rule_id)` | Match by stable `original_uuid` or title |
| `detect(content)` | Disambiguation helper for the format loader — triggers on ATR-specific markers |

The `detect()` method is implemented as a regular instance method (not `@abstractmethod`), so the existing `RuleType` contract in `rule_type_abstract.py` is **unchanged**. If/when the abstract grows a `detect()` method per the discussion in #49, this implementation already satisfies it.

## Style alignment with `sigma_format.py`

- Section header comment blocks (`# VALIDATION #`, `# META PARSING #`, etc.)
- Module imports in the same order (stdlib → third-party → app)
- Error-path return shape from `parse_metadata` mirrors sigma's "Metadata Error" fallback
- `detect_cve` usage matches sigma's contract: `cve_id` field is a JSON-encoded string, not a list, so downstream consumers don't need to branch on format
- Single-rule files returned verbatim in `extract_rules_from_file` (no `yaml.safe_dump`) — preserves quoting / key-ordering like sigma does

## ATR semantic validation

Beyond YAML parsing, `validate()` enforces:

- `id` matches `^ATR-\d{4}-\d{5}$`
- `severity` ∈ `{critical, high, medium, low}`
- `tags.category` ∈ the canonical 10-category ATR taxonomy
- `agent_source.type` recognised (additive — unknown types are warnings, not errors)
- `detection.conditions` is a non-empty array, each entry has `field` / `operator` / `value`
- `detection.condition` ∈ `{any, all, or, and}`

Output: `ValidationResult(ok, errors, warnings, normalized_content)`. `normalized_content` always returns the original input verbatim — never re-dumped.

## Tests

```
$ pytest tests/rules/test_atr_format.py -v
============================== 24 passed in 0.39s ==============================
```

Covers: format / class identifier, `detect()` (3 positive + 3 negative cases), `validate()` (canonical rule accepted + 7 distinct rejection paths), `parse_metadata()` (explicit CVE list, description fallback, tags flattening, error path), `get_rule_files()`, `extract_rules_from_file()` (single-rule verbatim, non-ATR-YAML returns empty, multi-doc).

Tests run inside the existing rulezet test environment (full `requirements.txt` + Flask app conftest). No additional dependencies introduced.

## Auto-registration

Per `load_all_rule_formats()` in `rule_type_abstract.py`, dropping the adapter into `available_format/` is sufficient — no manual registry edit needed.

## On the future `rulezet-cast` migration

@ecrou-exact mentioned in #49 that the format system is being lifted out to a separate repo (`rulezet/rulezet-cast`). This adapter is structured to migrate cleanly: zero modifications to existing rulezet-core files, full self-containment of the format logic, and no implicit dependencies on rulezet's internal data model beyond the documented `RuleType` contract.

## Upstream

- ATR repo: https://github.com/Agent-Threat-Rule/agent-threat-rules (MIT, v2.1.2 / 338 rules across 10 attack categories)
- MISP integration: taxonomies#323 + galaxy#1207, both merged 2026-05-10 by @adulau as MISP project lead
- Production deployments: Cisco AI Defense skill-scanner, Microsoft Agent Governance Toolkit (with weekly auto-sync)

Closes #49.